### PR TITLE
check migerating slots when remove server group

### DIFF
--- a/pkg/models/server_group.go
+++ b/pkg/models/server_group.go
@@ -153,6 +153,9 @@ func (self *ServerGroup) Remove(zkConn zkhelper.Conn) error {
 		if slot.GroupId == self.Id {
 			return errors.Errorf("group %d is using by slot %d", slot.GroupId, slot.Id)
 		}
+		if ((slot.State.Status == SLOT_STATUS_MIGRATE || slot.State.Status == SLOT_STATUS_PRE_MIGRATE) && slot.State.MigrateStatus.From == self.Id) {
+			return errors.Errorf("slot %d has residual data remain in group %d", slot.Id, self.Id)
+		}
 	}
 
 	// do delete


### PR DESCRIPTION
如果server-group还有迁移中的slot，删除group可能导致数据丢失，codis-config也无法恢复被中断的迁移任务。