### PR TITLE
codis-proxy: support auto-online and remove-fence after start

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -33,7 +33,9 @@ var (
 	configFile = "config.ini"
 )
 
-var usage = `usage: proxy [-c <config_file>] [-L <log_file>] [--log-level=<loglevel>] [--log-filesize=<filesize>] [--cpu=<cpu_num>] [--addr=<proxy_listen_addr>] [--http-addr=<debug_http_server_addr>]
+var usage = `
+usage: 
+   proxy [-c <config_file>] [-L <log_file>] [--log-level=<loglevel>] [--log-filesize=<filesize>] [--cpu=<cpu_num>] [--addr=<proxy_listen_addr>] [--http-addr=<debug_http_server_addr>] [--online] [--remove-fence] 
 
 options:
    -c	set config file
@@ -43,6 +45,8 @@ options:
    --cpu=<cpu_num>		num of cpu cores that proxy can use
    --addr=<proxy_listen_addr>		proxy listen address, example: 0.0.0.0:9000
    --http-addr=<debug_http_server_addr>		debug vars http server
+   --online		        set proxy online
+   --remove-fence       remove proxy/fence info
 `
 
 const banner string = `
@@ -163,11 +167,21 @@ func main() {
 		httpAddr = args["--http-addr"].(string)
 	}
 
+	autoOnline := false
+	if args["--online"] != nil {
+		autoOnline = true
+	}
+
+	removeFence := false
+	if args["--remove-fence"] != nil {
+		removeFence = true
+	}
+
 	checkUlimit(1024)
 	runtime.GOMAXPROCS(cpus)
 
 	http.HandleFunc("/setloglevel", handleSetLogLevel)
-	go func(){
+	go func() {
 		err := http.ListenAndServe(httpAddr, nil)
 		log.PanicError(err, "http debug server quit")
 	}()
@@ -180,7 +194,7 @@ func main() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, os.Kill)
 
-	s := proxy.New(addr, httpAddr, conf)
+	s := proxy.New(addr, httpAddr, removeFence, autoOnline, conf)
 	defer s.Close()
 
 	stats.PublishJSONFunc("router", func() string {

--- a/pkg/models/proxy.go
+++ b/pkg/models/proxy.go
@@ -95,6 +95,11 @@ func CreateProxyInfo(zkConn zkhelper.Conn, productName string, pi *ProxyInfo) (s
 	return zkConn.Create(path.Join(dir, pi.Id), data, zk.FlagEphemeral, zkhelper.DefaultFileACLs())
 }
 
+func RemoveProxyInfo(zkConn zkhelper.Conn, productName string, pi *ProxyInfo) error {
+	path := path.Join(GetProxyPath(productName), pi.Id)
+	return zkhelper.DeleteRecursive(zkConn, path, -1)
+}
+
 func GetProxyFencePath(productName string) string {
 	return fmt.Sprintf("/zk/codis/db_%s/fence", productName)
 }
@@ -102,6 +107,11 @@ func GetProxyFencePath(productName string) string {
 func CreateProxyFenceNode(zkConn zkhelper.Conn, productName string, pi *ProxyInfo) (string, error) {
 	return zkhelper.CreateRecursive(zkConn, path.Join(GetProxyFencePath(productName), pi.Addr), "",
 		0, zkhelper.DefaultFileACLs())
+}
+
+func RemoveProxyFenceNode(zkConn zkhelper.Conn, productName string, pi *ProxyInfo) error {
+	fencePath := path.Join(GetProxyFencePath(productName), pi.Addr)
+	return zkhelper.DeleteRecursive(zkConn, fencePath, -1)
 }
 
 func ProxyList(zkConn zkhelper.Conn, productName string, filter func(*ProxyInfo) bool) ([]ProxyInfo, error) {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -66,7 +66,7 @@ func init() {
 	err = models.SetSlotRange(conn, conf.productName, 512, 1023, 2, models.SLOT_STATUS_ONLINE)
 	assert.MustNoError(err)
 
-	s = New(":19000", ":11000", conf)
+	s = New(":19000", ":11000", false, false, conf)
 
 	err = models.SetProxyStatus(conn, conf.productName, conf.proxyId, models.PROXY_STATE_ONLINE)
 	assert.MustNoError(err)

--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -101,6 +101,14 @@ func (top *Topology) CreateProxyFenceNode(pi *models.ProxyInfo) (string, error) 
 	return models.CreateProxyFenceNode(top.zkConn, top.ProductName, pi)
 }
 
+func (top *Topology) RemoveProxyInfo(pi *models.ProxyInfo) error {
+	return models.RemoveProxyInfo(top.zkConn, top.ProductName, pi)
+}
+
+func (top *Topology) RemoveProxyFenceNode(pi *models.ProxyInfo) error {
+	return models.RemoveProxyFenceNode(top.zkConn, top.ProductName, pi)
+}
+
 func (top *Topology) GetProxyInfo(proxyName string) (*models.ProxyInfo, error) {
 	return models.GetProxyInfo(top.zkConn, top.ProductName, proxyName)
 }


### PR DESCRIPTION
在实际使用中，codis-proxy会由于某些原因挂掉； 我们通过 supervisor 来重启 codis-proxy； 但是会由于 fence 导致起不来； 所以增加  --remove-fence 选项，可以强制 remove-fence； 
当 proxy 重启后，希望能自动 online， 所以增加  --online 选项 （本来想用 --auto-online， 结果发现用不了）

 